### PR TITLE
Restore Last Opened Item module -- v1

### DIFF
--- a/app/scripts.ts/sc_ext.ts
+++ b/app/scripts.ts/sc_ext.ts
@@ -680,6 +680,76 @@ namespace SitecoreExtensions.Modules.Launcher {
     }
 }
 
+namespace SitecoreExtensions.Modules.LastLocation {
+    import ICommandsProvider = SitecoreExtensions.Modules.Launcher.Providers.ICommandsProvider;
+    import ICommand = SitecoreExtensions.Modules.Launcher.ICommand;
+    declare var scForm: any;
+    
+    class LastLocationStore {
+        private static LocalStorageKey : string = "sc_ext::last_item";
+        
+        public static saveLastItemId(id : string) : void {
+            localStorage.setItem(this.LocalStorageKey, id);
+        }
+        
+        public static loadLastItemId() : string {
+            return localStorage.getItem(this.LocalStorageKey);
+        }
+    }
+    
+    export class RestoreLastLocation extends SitecoreExtensions.Modules.ModuleBase implements SitecoreExtensions.Modules.ISitecoreExtensionsModule {
+        canExecute(): boolean {
+            return SitecoreExtensions.Context.Location() == Location.ContentEditor;
+        }
+        
+        updateLastLocation(args : any): void {
+            var id;
+            for (let i=0,l=args.path.length;i<l;i++){
+                let parent = args.path[i];
+                if(parent.tagName && parent.tagName.toLowerCase() === "a"){
+                    id = parent.id;
+                    id = id.substring(id.lastIndexOf("_") + 1);
+                    LastLocationStore.saveLastItemId(id);
+                    break;
+                }
+            }
+        }
+        
+        addTreeNodeHandlers(className: string): void {
+            var nodes = document.getElementsByClassName(className);
+            for (var i = 0; i < nodes.length; i++) {
+                nodes[i].addEventListener('click', (evt) => {
+                    this.updateLastLocation(evt);
+                });
+            }
+        }
+
+        initialize(): void {
+            this.addTreeNodeHandlers('scContentTree');
+        }
+    }
+    
+    export class RestoreLastLocationCommandProvider implements ICommandsProvider {
+        getCommands(): ICommand[] {
+            var cmd: ICommand = {
+                    id: 0,
+                    name: "Restore Last Opened Item",
+                    description: "Restores last opened item in Content Editor",
+                    execute: () => { 
+                        var lastItem = LastLocationStore.loadLastItemId();
+                        if(lastItem){
+                            scForm.postRequest("", "", "", "LoadItem(\"" + lastItem + "\")");
+                        }
+                     },
+                    canExecute: () => { return SitecoreExtensions.Context.Location() == Location.ContentEditor; }
+                };
+            return [
+                cmd
+            ];
+        }
+    }
+}
+
 namespace SitecoreExtensions {
     import ISitecoreExtensionsModule = SitecoreExtensions.Modules.ISitecoreExtensionsModule;
     export class ExtensionsManager {
@@ -781,16 +851,19 @@ if (SitecoreExtensions.Context.IsValid()) {
     var dbNameModule = new SitecoreExtensions.Modules.DatabaseName.DatabaseNameModule('Database Name', 'Displays current database name in the Content Editor header');
     var launcher = new SitecoreExtensions.Modules.Launcher.LauncherModule('Launcher', 'Feel like power user using Sitecore Extensions command launcher.');
     var databaseColour = new SitecoreExtensions.Modules.DatabaseColor.DatabaseColorModule("Database Colour", 'Change the global header colour depeding on current database.');
+    var lastLocation = new SitecoreExtensions.Modules.LastLocation.RestoreLastLocation("Restore Last Location","Restores last opened item in Content Editor");
 
     scExtManager.addModule(sectionSwitchesModule);
     scExtManager.addModule(dbNameModule);
     scExtManager.addModule(launcher);
     scExtManager.addModule(databaseColour);
+    scExtManager.addModule(lastLocation);
 
     scExtManager.initModules();
 
 
-    launcher.registerProviderCommands(new SitecoreExtensions.Modules.SectionSwitches.SectionSwitchesCommandsProvider())
+    launcher.registerProviderCommands(new SitecoreExtensions.Modules.SectionSwitches.SectionSwitchesCommandsProvider());
+    launcher.registerProviderCommands(new SitecoreExtensions.Modules.LastLocation.RestoreLastLocationCommandProvider());
 
     window.postMessage({
         sc_ext_enabled: true,


### PR DESCRIPTION
Initial version of command which restores last opened item in Content Editor (handles annoying session-end = content editor refresh issue).
